### PR TITLE
Fix pod ngi14 image pull failure

### DIFF
--- a/k8s/pod-ngi14.yaml
+++ b/k8s/pod-ngi14.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ngi14
+  namespace: kagent
+  annotations:
+    ambient.istio.io/redirection: enabled
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 80
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-sgcbf
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  # nodeName: talos-9kw-b68  # Commented out for generality
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: kube-api-access-sgcbf
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          name: kube-root-ca.crt
+      - downwardAPI:
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace


### PR DESCRIPTION
The pod ngi14 was failing due to invalid image tag "nginx:latesttttt". This PR adds a fixed pod manifest with "nginx:latest". Deploy this to recreate the pod. Related issue: #2