### PR TITLE
Fix ImagePullBackOff for pod ngi14

### DIFF
--- a/k8s/fix-ngi14-pod.yaml
+++ b/k8s/fix-ngi14-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ngi14
+  namespace: default
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
Updates the pod manifest to use correct nginx image tag. References issue #4.